### PR TITLE
BATIAI-303 Simplify cluster deployments by making the 1-* scripts part of the TF rollout

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -18,6 +18,11 @@ output "private_subnets" {
   value       = data.aws_subnets.private.ids
 }
 
+output "private_subnets_by_zone" {
+  description = "map of AZs to private subnet ids"
+  value       = { for subnet in data.aws_subnet.private : subnet.availability_zone => subnet.id }
+}
+
 output "public_subnets" {
   description = "List of IDs of public subnets"
   value       = data.aws_subnets.public.ids

--- a/outputs.tf
+++ b/outputs.tf
@@ -43,6 +43,11 @@ output "transport_subnets_by_zone" {
   value       = { for subnet in data.aws_subnet.transport : subnet.availability_zone => subnet.id }
 }
 
+output "container_subnets_by_zone" {
+  description = "map of AZs to container subnet ids"
+  value       = { for container in data.aws_subnet.container : container.availability_zone => container.id }
+}
+
 output "cmscloud_vpn_pl" {
   description = "Prefix list of cmscloud vpn"
   value       = data.aws_ec2_managed_prefix_list.vpn_prefix_list.id


### PR DESCRIPTION
## Fixes Issue: [BATIAI-303](https://jiraent.cms.gov/browse/BATIAI-303)

## Description
Simplify cluster deployments by making the 1-* scripts part of the TF rollout
